### PR TITLE
feat: Remove printing a decrypted AES key & made namespace non-const

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 lib_deps = 
-    jeremytubongbanua/at_client@^0.2.3
+    jeremytubongbanua/at_client@^0.2.4
 monitor_speed = 115200
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ platform = espressif32
 board = esp32dev
 framework = arduino
 lib_deps = 
-    jeremytubongbanua/at_client@^0.2.2
+    jeremytubongbanua/at_client@^0.2.3
 monitor_speed = 115200
 ```
 

--- a/include/at_key.h
+++ b/include/at_key.h
@@ -108,7 +108,7 @@ public:
             s += shared_with->get_value() + ":";
         }
         s += key;
-        if (namespace_str.empty())
+        if (!namespace_str.empty())
         {
             s += "." + namespace_str;
         }

--- a/include/at_key.h
+++ b/include/at_key.h
@@ -86,7 +86,7 @@ class AtKey
 
 public:
     const std::string key;
-    const std::string namespace_str;
+    std::string namespace_str;
     const AtSign *shared_by; // the atSign that this key is sharedBy (creator)
     const AtSign *shared_with; // the atSign that this key is sharedWith (could be nullptr)
     Metadata *metadata;

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "at_client",
-    "version": "0.2.3",
+    "version": "0.2.4",
     "description": "atPlatform implementation in the ESP32 (Arduino C++)",
     "keywords": "encryption, aes256ctr, aesctr, aes, aes256, rsa, rsa2048, privacy, platform, framework",
     "repository": {

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "at_client",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "atPlatform implementation in the ESP32 (Arduino C++)",
     "keywords": "encryption, aes256ctr, aesctr, aes, aes256, rsa, rsa2048, privacy, platform, framework",
     "repository": {

--- a/src/at_client.cpp
+++ b/src/at_client.cpp
@@ -80,7 +80,6 @@ std::string AtClient::get_aes_key_shared_by_them(const AtSign *at_sign_shared_by
 
     // decrypt aes_key_base64_encrypted with rsa_public_key
     const auto aes_key_base64 = rsa_2048::decrypt(aes_key_base64_encrypted, rsa_private_key);
-    std::cout << "aes_key_base64 decrypted: \"" << aes_key_base64 << "\"" << std::endl;
 
     return aes_key_base64;
 }

--- a/src/at_client.cpp
+++ b/src/at_client.cpp
@@ -188,7 +188,7 @@ void AtClient::put_ak(const AtKey &at_key, const std::string &value)
         command = "update:" + at_key.shared_with->get_value() + ":" + at_key.key;
         if(!at_key.namespace_str.empty())
         {
-            command = command + at_key.namespace_str;
+            command = command + "." + at_key.namespace_str;
 
         }
         command = command + at_key.shared_by->get_value() + " " + encrypted_value;

--- a/src/at_client.cpp
+++ b/src/at_client.cpp
@@ -94,7 +94,6 @@ std::string AtClient::get_aes_key_shared_by_me(const AtSign *at_sign_shared_with
 
     // decrypt aes_key_base64_encrypted with rsa_public_key
     const auto aes_key_base64 = rsa_2048::decrypt(aes_key_base64_encrypted, rsa_private_key);
-    std::cout << "aes_key_base64 decrypted: \"" << aes_key_base64 << "\"" << std::endl;
 
     return aes_key_base64;
 }


### PR DESCRIPTION
Two changes:

- removed 2 print statements printing the decrypted AES key
- made namespace non-const so that it can be editable