### PR TITLE
ci: Add Cppcheck workflow

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,20 @@
+name: Cppcheck
+on:
+  workflow_dispatch:
+  push:
+    branches: [trunk]
+  pull_request:
+    branches: [trunk]
+
+permissions:
+  contents: read
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Cppcheck
+        run: |
+          sudo apt install -y cppcheck
+          cppcheck .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.2.6
+
+- Cppcheck workflow
+
 ## v0.2.5
 
 - OSSF Scorecard

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "at_client",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "description": "atPlatform implementation in the ESP32 (Arduino C++)",
     "keywords": "encryption, aes256ctr, aesctr, aes, aes256, rsa, rsa2048, privacy, platform, framework",
     "repository": {


### PR DESCRIPTION
Adding a linter, which we can make a mandatory CI check

**- What I did**

Added a workflow to install and run [Cppcheck](https://cppcheck.sourceforge.io/)

**- How I did it**

Based on unit test workflows we run elsewhere

**- How to verify it**

Look at logs from action run for this PR

**- Description for the changelog**

ci: Add Cppcheck workflow