### PR TITLE
fix: Specific read perms rather than read-all

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -15,14 +15,19 @@ on:
     branches: [ "trunk" ]
 
 permissions:
-  # Required when publishing results (badge / API / code scanning)
-  security-events: write
-  id-token: write
-  # Recommended reads to avoid GraphQL/SAST gaps
-  contents: read
-  issues: read
-  pull-requests: read
+  actions: read
+  artifact-metadata: read
+  attestations: read
   checks: read
+  contents: read
+  deployments: read
+  issues: read
+  models: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  statuses: read
 
 jobs:
   analysis:


### PR DESCRIPTION
Scorecard action isn't working properly with permissions that were set to appease Sonarqube

**- What I did**

Explicit read permissions at workflow level for all things that aren't defined at job level (equivalent to a read-all)

**- How I did it**

Based on https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#defining-access-for-the-github_token-scopes

**- How to verify it**

Will need to be merged to trunk for another scorecard action run

**- Description for the changelog**

fix: Specific read perms rather than read-all
